### PR TITLE
Add Flutter test page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+import 'test_page.dart';
+
+void main() {
+  runApp(const MaterialApp(
+    home: TestPage(),
+  ));
+}

--- a/lib/test_page.dart
+++ b/lib/test_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+/// An example page that displays a simple greeting.
+class TestPage extends StatelessWidget {
+  const TestPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Test Page')),
+      body: const Center(child: Text('Hello from Test Page')),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- document `TestPage` widget with a simple greeting
- add a `main.dart` example that uses `TestPage`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d78e5d6483299a1dc9cb04d15ac1